### PR TITLE
zero pad nums to 2 digits

### DIFF
--- a/app/javascript/controllers/countdown_controller.js
+++ b/app/javascript/controllers/countdown_controller.js
@@ -27,10 +27,15 @@ export default class extends Controller {
     const secondsPerHour = 3600;
     const secondsPerMinute = 60;
 
-    const days = Math.floor(secondsRemaining / secondsPerDay);
-    const hours = Math.floor((secondsRemaining % secondsPerDay) / secondsPerHour);
-    const minutes = Math.floor((secondsRemaining % secondsPerHour) / secondsPerMinute);
-    const seconds = Math.floor(secondsRemaining % secondsPerMinute);
+    function zeroPad(number) {
+      number = ("00"+number).slice(-2);
+      return number
+    }
+
+    const days = zeroPad(Math.floor(secondsRemaining / secondsPerDay));
+    const hours = zeroPad(Math.floor((secondsRemaining % secondsPerDay) / secondsPerHour));
+    const minutes = zeroPad(Math.floor((secondsRemaining % secondsPerHour) / secondsPerMinute));
+    const seconds = zeroPad(Math.floor(secondsRemaining % secondsPerMinute));
 
     this.countdownTarget.innerHTML = `${days}${hours}${minutes}${seconds}`
   }


### PR DESCRIPTION
Problem: When each set of numbers goes from double digits to single it can create confusion as well as change the width of the string.

Solution: Add a leading 0 when numbers reduce below 10.